### PR TITLE
Ensure the player data used to replace variables is set

### DIFF
--- a/src/main/java/me/lxct/bestviewdistance/commands/ViewCommand.java
+++ b/src/main/java/me/lxct/bestviewdistance/commands/ViewCommand.java
@@ -2,6 +2,8 @@ package me.lxct.bestviewdistance.commands;
 
 import me.lxct.bestviewdistance.functions.util.Misc;
 import me.lxct.bestviewdistance.functions.data.Variable;
+
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -14,6 +16,13 @@ public class ViewCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Sadly, this requires a player.");
+            return true;
+        }
+
+        playerData = onlinePlayers.get(sender);
+
         if (cmd.getName().equalsIgnoreCase("view")) {
             if (args.length == 0) {
                 commandHelp(sender);
@@ -24,26 +33,23 @@ public class ViewCommand implements CommandExecutor {
                     commandPing(args, sender);
                     commandView(args, sender);
                 }
+
                 if (sender.hasPermission("view.reload")) {
                     commandReload(args, sender);
                 }
             }
         } else if (cmd.getName().equalsIgnoreCase("vdist") && sender.hasPermission("view.info")) {
-            if (sender instanceof Player) {
-                playerData = onlinePlayers.get(sender);
-                sender.sendMessage(colorize(Misc.replacePlaceHolders(vdistLine1)));
-                sender.sendMessage(colorize(Misc.replacePlaceHolders(vdistLine2)));
-                sender.sendMessage(colorize(Misc.replacePlaceHolders(vdistLine3)));
-                if (!Variable.hideVdistLine4) {
-                    sender.sendMessage(colorize(Misc.replacePlaceHolders(vdistLine4)));
-                }
+            sender.sendMessage(colorize(Misc.replacePlaceHolders(vdistLine1)));
+            sender.sendMessage(colorize(Misc.replacePlaceHolders(vdistLine2)));
+            sender.sendMessage(colorize(Misc.replacePlaceHolders(vdistLine3)));
+
+            if (!Variable.hideVdistLine4) {
+                sender.sendMessage(colorize(Misc.replacePlaceHolders(vdistLine4)));
             }
         } else if (cmd.getName().equalsIgnoreCase("vping") && sender.hasPermission("view.info")) {
-            if (sender instanceof Player) {
-                playerData = onlinePlayers.get(sender);
-                sender.sendMessage(colorize(Misc.replacePlaceHolders(vping)));
-            }
+            sender.sendMessage(colorize(Misc.replacePlaceHolders(vping)));
         }
+
         return true;
     }
 }


### PR DESCRIPTION
Fixes #13. The variable replacer requires a player since it expects the playerdata to be set and console is not a player, neither is not setting it.